### PR TITLE
Add flag name linter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           ruby-version: ${{ env.RUBY_VERSION }}
-
-      - name: Install dependencies
-        run: |
-          gem install bundler
-          bundle install
 
       - name: Test
         run: bundle exec rspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          bundler-cache: true
           ruby-version: ${{ env.RUBY_VERSION }}
 
       - name: Test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-chr (0.1.0)
+    rubocop-chr (0.2.0)
       rubocop
 
 GEM
@@ -46,6 +46,7 @@ GEM
     unicode-display_width (2.2.0)
 
 PLATFORMS
+  ruby
   x86_64-linux
 
 DEPENDENCIES
@@ -56,4 +57,4 @@ DEPENDENCIES
   rubocop-chr!
 
 BUNDLED WITH
-   2.3.9
+   2.4.10

--- a/config/default.yml
+++ b/config/default.yml
@@ -26,7 +26,7 @@ Rails5/StringConditional:
   VersionAdded: '0.50'
 
 Flag/FeatureFlagName:
-  Description: 'Feature Flag Name is a cop that checks for if feature flag name is following TELUS specifications.'
+  Description: 'Feature Flag Name is a cop that checks for if feature flag name is following snake_case format.'
   Enabled: true
   SafeAutocorrect: false
   VersionAdded: '0.50'

--- a/config/default.yml
+++ b/config/default.yml
@@ -24,3 +24,9 @@ Rails5/StringConditional:
   Enabled: true
   SafeAutocorrect: false
   VersionAdded: '0.50'
+
+Flag/FeatureFlagName:
+  Description: 'Feature Flag Name is a cop that checks for if feature flag name is following TELUS specifications.'
+  Enabled: true
+  SafeAutocorrect: false
+  VersionAdded: '0.50'

--- a/lib/rubocop/chr/version.rb
+++ b/lib/rubocop/chr/version.rb
@@ -1,5 +1,5 @@
 module RuboCop
   module Chr
-    VERSION = "0.1.0".freeze
+    VERSION = "0.2.0".freeze
   end
 end

--- a/lib/rubocop/cop/chr_cops.rb
+++ b/lib/rubocop/cop/chr_cops.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
+require_relative 'flag/feature_flag_name'
 require_relative 'rails5/string_conditional'

--- a/lib/rubocop/cop/flag/feature_flag_name.rb
+++ b/lib/rubocop/cop/flag/feature_flag_name.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Flag
+      # The Feature Flag Name Cop is used to identify flag names that are not
+      # using the sneak case pattern.
+      #
+      # @example
+      #   # bad
+      #   if FeatureFlag.enabled? 'SEARCH_MY_FLAG_ID'
+      #
+      #   # good
+      #   if FeatureFlag.enabled? 'search_my_flag_id'
+      class FeatureFlagName < Base
+        def_node_matcher :feature_flag_name, <<~PATTERN
+        (send
+          (const nil? :FeatureFlag) :enabled?
+          (str $_))
+        PATTERN
+
+        RESTRICT_ON_SEND = [:enabled?].freeze
+
+        def on_send(node)
+          feature_flag_name(node) do |name|
+            next if to_snake_case(name) == name
+
+            add_offense(node, message: 'Use snake_case with lowercase for feature flag names.')
+          end
+        end
+
+        def to_snake_case(word)
+          word
+            .to_s
+            .gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
+            .gsub(/([a-z\d])([A-Z])/, '\1_\2')
+            .tr('-', '_')
+            .downcase
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/flag/feature_flag_name.rb
+++ b/lib/rubocop/cop/flag/feature_flag_name.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     module Flag
       # The Feature Flag Name Cop is used to identify flag names that are not
-      # using the sneak case pattern.
+      # using the snake case pattern.
       #
       # @example
       #   # bad

--- a/spec/rubocop/cop/flag/feature_flag_name_spec.rb
+++ b/spec/rubocop/cop/flag/feature_flag_name_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Flag::FeatureFlagName, :config do
+  let(:config) { RuboCop::Config.new }
+
+  it 'registers an offense when using an invalid feature flag name' do
+    # An error occurred while CustomCops/FeatureFlagName cop was
+    # inspecting /Users/rafaelrocha/src/telus/chr-backend/app/models/
+    # respondent/searchable_value.rb:32:11
+    expect_offense(<<~RUBY)
+      if FeatureFlag.enabled? 'SEARCH_MY_FLAG_ID'
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use snake_case with lowercase for feature flag names.
+      end
+    RUBY
+  end
+
+  it 'registers no offense when using a valid feature flag name' do
+    expect_no_offenses(<<~RUBY)
+      if FeatureFlag.enabled? 'search_my_flag_id'
+      end
+    RUBY
+  end
+end

--- a/spec/rubocop/cop/flag/feature_flag_name_spec.rb
+++ b/spec/rubocop/cop/flag/feature_flag_name_spec.rb
@@ -4,9 +4,6 @@ RSpec.describe RuboCop::Cop::Flag::FeatureFlagName, :config do
   let(:config) { RuboCop::Config.new }
 
   it 'registers an offense when using an invalid feature flag name' do
-    # An error occurred while CustomCops/FeatureFlagName cop was
-    # inspecting /Users/rafaelrocha/src/telus/chr-backend/app/models/
-    # respondent/searchable_value.rb:32:11
     expect_offense(<<~RUBY)
       if FeatureFlag.enabled? 'SEARCH_MY_FLAG_ID'
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use snake_case with lowercase for feature flag names.


### PR DESCRIPTION
## Implementation Highlights
In order to avoid having flags name with different patterns, a linter was created to help developers use the snake_case format while creating new flags. 

The Rubocop Linter will run looking for IF conditions with Feature Flag names.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated if you fix a bug or add a feature.
