### PR TITLE
CHR-28321 - Prevent json/jsonb fields with string as default on database (Rails 5)

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -25,6 +25,12 @@ Rails5/StringConditional:
   SafeAutocorrect: false
   VersionAdded: '0.50'
 
+Rails5/NoStringDefaultForJson:
+  Description: 'NoStringDefaultForJson is a cop that no new json or jsonb fields have string default values.'
+  Enabled: true
+  SafeAutocorrect: false
+  VersionAdded: '0.50'
+
 Flag/FeatureFlagName:
   Description: 'Feature Flag Name is a cop that checks for if feature flag name is following snake_case format.'
   Enabled: true

--- a/lib/rubocop/cop/chr_cops.rb
+++ b/lib/rubocop/cop/chr_cops.rb
@@ -2,3 +2,4 @@
 
 require_relative 'flag/feature_flag_name'
 require_relative 'rails5/string_conditional'
+require_relative 'rails5/no_string_default_for_json'

--- a/lib/rubocop/cop/rails5/no_string_default_for_json.rb
+++ b/lib/rubocop/cop/rails5/no_string_default_for_json.rb
@@ -20,7 +20,7 @@ module RuboCop
       #     t.jsonb :visible_values, default: []
       #   end
       #
-      #   # bad
+      #   # good
       #   change_column :questions, :attr, :json, default: {}
       class NoStringDefaultForJson < Cop
         MSG = 'Do not use string as a default value for JSON or JSONB columns. Column: %<column>s'.freeze

--- a/lib/rubocop/cop/rails5/no_string_default_for_json.rb
+++ b/lib/rubocop/cop/rails5/no_string_default_for_json.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Rails5
+      # This cop checks for migrations with JSON or JSONB columns
+      # that have a default value of string.
+      # On Rails 5 and above, we should use a hash or array as a default value.
+      # @example
+      #   # bad
+      #   create_table :test_supporters do |t|
+      #     t.jsonb :visible_values, default: '[]'
+      #   end
+      #
+      #   # bad
+      #   change_column :questions, :attr, :json, default: '{}'
+      #
+      #   # good
+      #   create_table :test_supporters do |t|
+      #     t.jsonb :visible_values, default: []
+      #   end
+      #
+      #   # bad
+      #   change_column :questions, :attr, :json, default: {}
+      class NoStringDefaultForJson < Cop
+        MSG = 'Do not use string as a default value for JSON or JSONB columns. Column: %<column>s'.freeze
+
+        RESTRICT_ON_SEND = %i[json jsonb add_column change_column].freeze
+
+        # t.jsonb :visible_values, default: '[]'
+        def_node_matcher :json_column_with_string_default_on_create?, <<~PATTERN
+          (send _ {:json :jsonb} (sym $_) (hash (pair (sym :default) (str _))))
+        PATTERN
+
+        # add_column :questions, :resource_data, :json, default: '{}'
+        # change_column :questions, :archive_data, :json, default: '{}'
+        def_node_matcher :json_column_with_string_default_on_change?, <<~PATTERN
+          (send nil? {:add_column :change_column} (sym _) (sym $_) (sym {:json :jsonb}) (hash (pair (sym :default) (str _))))
+        PATTERN
+
+        def on_send(node)
+          json_column_with_string_default_on_create?(node) do |column|
+            add_offense(node, message: format(MSG, column: column))
+          end
+
+          json_column_with_string_default_on_change?(node) do |column|
+            add_offense(node, message: format(MSG, column: column))
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/rails5/no_string_default_for_json_spec.rb
+++ b/spec/rubocop/cop/rails5/no_string_default_for_json_spec.rb
@@ -26,4 +26,14 @@ RSpec.describe RuboCop::Cop::Rails5::NoStringDefaultForJson, :config do
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use string as a default value for JSON or JSONB columns. Column: archive_data
     RUBY
   end
+
+  it 'does not register offenses when using objects as default values' do
+    expect_no_offenses(<<~RUBY)
+      add_column :appointments, :more_data, :json, default: []
+    RUBY
+
+    expect_no_offenses(<<~RUBY)
+      change_column :questions, :archive_data, :jsonb, default: {}
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/rails5/no_string_default_for_json_spec.rb
+++ b/spec/rubocop/cop/rails5/no_string_default_for_json_spec.rb
@@ -36,4 +36,14 @@ RSpec.describe RuboCop::Cop::Rails5::NoStringDefaultForJson, :config do
       change_column :questions, :archive_data, :jsonb, default: {}
     RUBY
   end
+
+  it 'does not register offenses when not defining a default value' do
+    expect_no_offenses(<<~RUBY)
+      add_column :appointments, :more_data, :json
+    RUBY
+
+    expect_no_offenses(<<~RUBY)
+      change_column :questions, :archive_data, :jsonb
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/rails5/no_string_default_for_json_spec.rb
+++ b/spec/rubocop/cop/rails5/no_string_default_for_json_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Rails5::NoStringDefaultForJson, :config do
+  let(:config) { RuboCop::Config.new }
+
+  it 'registers an offense when using string as default value for json field on create_table' do
+    expect_offense(<<~RUBY)
+      t.json :archive_data, default: '{}'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use string as a default value for JSON or JSONB columns. Column: archive_data
+    RUBY
+
+    expect_offense(<<~RUBY)
+      t.jsonb :archive_data, default: '[]'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use string as a default value for JSON or JSONB columns. Column: archive_data
+    RUBY
+  end
+
+  it 'registers an offense when using string as default value for json field on add_column/change_colum' do
+    expect_offense(<<~RUBY)
+      add_column :appointments, :more_data, :json, default: '[]'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use string as a default value for JSON or JSONB columns. Column: more_data
+    RUBY
+
+    expect_offense(<<~RUBY)
+      change_column :questions, :archive_data, :jsonb, default: '{}'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use string as a default value for JSON or JSONB columns. Column: archive_data
+    RUBY
+  end
+end


### PR DESCRIPTION
[https://inputhealth.atlassian.net/browse/CHR-28321](https://inputhealth.atlassian.net/browse/CHR-28321)

This change fixes errors on

```
spec/acceptance/provider/settings/ebooking/on_time_templates_spec.rb
and others
```


## Error

```ruby
Failure/Error: expect(status).to be_http_status(200)

            Expected status 200 but got 500
            Response body:
            ActiveRecord::StatementInvalid at /settings/on-time-templates
            =============================================================

            PG::InvalidParameterValue: ERROR:  cannot extract elements from a scalar
            : SELECT DISTINCT "account_schedule_templates".* FROM "account_schedule_templates"
            INNER JOIN (      SELECT id, hours_datum
                  FROM account_schedule_templates, jsonb_array_elements(hours_data) hours_datum
                  WHERE hours_datum->>'location_id' = '9250'
            ) AS hours ON hours.id = account_schedule_templates.id WHERE "account_schedule_templates"."type"
             IN ('Account::ScheduleTemplate::OnTime') AND "account_schedule_templates"."account_id" = $1
              AND (account_schedule_templates.archived IS NULL OR account_schedule_templates.archived = false)
               ORDER BY "account_schedule_templates"."position" ASC
```

## Implementation Highlights

Rails 5 does not serialize correctly json/jsonb fields using strings `'{}'` or `'[]'` as default values.

[Upgrading Ruby on Rails — Ruby on Rails Guides](https://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#changes-with-json-jsonb-serialization)

But if using objects `{}` and `[]` is fine for both Rails 4 and 5

To fix this, we need to

Add a Rubocop cop to prevent the creation of more fields using string.

Add a migration to change the current string default values to objects (Future PR)

[https://inputhealth.atlassian.net/browse/CHR-28321](https://inputhealth.atlassian.net/browse/CHR-28321)